### PR TITLE
[Feat] Split gt and uad pred mask in annotation and calcuate auroc fo…

### DIFF
--- a/inference_plots.py
+++ b/inference_plots.py
@@ -131,7 +131,7 @@ for image_name, dict_annot in train_set.items():
         image_name,
         save_path,
         rank=4,
-        mask_path=dict_annot["mask_path"],
+        mask_path=dict_annot["gt_path"],
         bbox=dict_annot["bbox"],
         is_baseline=True,
     )
@@ -146,7 +146,7 @@ for image_name, dict_annot in test_set.items():
         image_name,
         save_path,
         rank=4,
-        mask_path=dict_annot["mask_path"],
+        mask_path=dict_annot["gt_path"],
         bbox=dict_annot["bbox"],
         is_baseline=True,
     )
@@ -182,7 +182,7 @@ for rank in ranks:
             image_name,
             save_path,
             rank=rank,
-            mask_path=dict_annot["mask_path"],
+            mask_path=dict_annot["gt_path"],
             bbox=dict_annot["bbox"],
             is_baseline=False,
         )
@@ -197,7 +197,7 @@ for rank in ranks:
             image_name,
             save_path,
             rank=rank,
-            mask_path=dict_annot["mask_path"],
+            mask_path=dict_annot["gt_path"],
             bbox=dict_annot["bbox"],
             is_baseline=False,
         )

--- a/src/dataloader.py
+++ b/src/dataloader.py
@@ -1,6 +1,6 @@
 import torch
 import glob
-import os 
+import os
 from PIL import Image
 import numpy as np
 
@@ -13,7 +13,8 @@ from src.processor import Samprocessor
 from src.segment_anything import build_sam_vit_b, SamPredictor
 from src.lora import LoRA_sam
 import src.utils as utils
-import yaml
+import pickle
+import random
 
 
 class DatasetSegmentation(Dataset):
@@ -22,8 +23,8 @@ class DatasetSegmentation(Dataset):
 
     Arguments:
         folder_path (str): The path of the folder containing the images
-        processor (obj): Samprocessor class that helps pre processing the image, and prompt 
-    
+        processor (obj): Samprocessor class that helps pre processing the image, and prompt
+
     Return:
         (dict): Dictionnary with 4 keys (image, original_size, boxes, ground_truth_mask)
             image: image pre processed to 1024x1024 size
@@ -32,42 +33,82 @@ class DatasetSegmentation(Dataset):
             ground_truth_mask: Ground truth mask
     """
 
-    def __init__(self, annotations: dict, processor: Samprocessor, mode: str):
-        super().__init__()        
-        self.img_files, self.mask_files = [], []
+    def __init__(
+        self,
+        annotations: dict,
+        processor: Samprocessor,
+        mode: str,
+        gt_ratio: float = 0.1,
+        random_seed: int = 42,
+    ):
+        super().__init__()
+        random.seed(random_seed)
+        self.img_files, self.evaluate_files, self.train_files = [], [], []
+        self.gt_ratio = gt_ratio
         for img_path, value in annotations[mode].items():
             self.img_files.append(img_path)
-            self.mask_files.append(value["mask_path"])
+            self.evaluate_files.append(value["gt_path"])
+            self.train_files.append(value["uad_pred_path"])
+
+        # Replace train files with ground truth via gt_ratio
+        if (mode == "train") and (gt_ratio > 0):
+            n_data = len(self.img_files)
+            n_gt_train = int(n_data * gt_ratio)
+            replaced_idx = random.sample(range(n_data), n_gt_train)
+            for idx in replaced_idx:
+                self.train_files[idx] = self.evaluate_files[idx]
+
+        # Get the anomaly map of UAD 
+        if mode == "test": 
+            self.uad_anomaly_maps = []
+            for img_path, value in annotations["test"].items():
+                self.uad_anomaly_maps.append(value["uad_pred_path"].replace("images", "anomaly_maps").replace(".png", ".pickle"))
 
         self.processor = processor
 
     def __len__(self):
         return len(self.img_files)
-    
-    def __getitem__(self, index: int) -> list:
-            img_path = self.img_files[index]
-            mask_path = self.mask_files[index]
-            # get image and mask in PIL format
-            image =  Image.open(img_path)
-            mask = Image.open(mask_path)
-            mask = mask.convert('1')
-            ground_truth_mask =  np.array(mask)
-            original_size = tuple(image.size)[::-1]
-    
-            # get bounding box prompt
-            box = utils.get_bounding_box(ground_truth_mask)
-            inputs = self.processor(image, original_size, box)
-            inputs["ground_truth_mask"] = torch.from_numpy(ground_truth_mask)
 
-            return inputs
-    
+    def __getitem__(self, index: int) -> list:
+        img_path = self.img_files[index]
+        train_mask_path = self.train_files[index]
+        evaluate_mask_path = self.evaluate_files[index]
+
+        # get image and train mask in PIL format
+        image = Image.open(img_path)
+        train_mask = Image.open(train_mask_path)
+        train_mask = train_mask.convert("1")
+        train_mask = np.array(train_mask)
+        original_size = tuple(image.size)[::-1]
+
+        # get bounding box prompt
+        box = utils.get_bounding_box(train_mask)
+        inputs = self.processor(image, original_size, box)
+        inputs["train_mask"] = torch.from_numpy(train_mask)
+
+        # add evaluate mask
+        evaluate_mask = Image.open(evaluate_mask_path)
+        evaluate_mask = evaluate_mask.convert("1")
+        evaluate_mask = np.array(evaluate_mask)
+        inputs["evaluate_mask"] = torch.from_numpy(evaluate_mask)
+
+        # get anomaly map if test
+        if len(self.uad_anomaly_maps) > 0:
+            with open(self.uad_anomaly_maps[index], "rb") as f:
+                uad_anomaly_map = pickle.load(f)
+                f.close()
+            inputs["anomaly_map"] = uad_anomaly_map
+
+        return inputs
+
+
 def collate_fn(batch: torch.utils.data) -> list:
     """
     Used to get a list of dict as output when using a dataloader
 
     Arguments:
         batch: The batched dataset
-    
+
     Return:
         (list): list of batched dataset so a list(dict)
     """

--- a/src/utils.py
+++ b/src/utils.py
@@ -98,7 +98,7 @@ def stacking_batch(batch, outputs):
         stk_gt: Stacked tensor of the ground truth masks in the batch. Shape: [batch_size, H, W] -> We will need to add the channels dimension (dim=1)
         stk_out: Stacked tensor of logits mask outputed by SAM. Shape: [batch_size, 1, 1, H, W] -> We will need to remove the extra dimension (dim=1) needed by SAM 
     """
-    stk_gt = torch.stack([b["ground_truth_mask"] for b in batch], dim=0)
+    stk_gt = torch.stack([b["train_mask"] for b in batch], dim=0)
     stk_out = torch.stack([out["low_res_logits"] for out in outputs], dim=0)
         
     return stk_gt, stk_out

--- a/train.py
+++ b/train.py
@@ -56,7 +56,7 @@ for rank in ranks:
 
     # Process the dataset
     processor = Samprocessor(model)
-    train_ds = DatasetSegmentation(annotations, processor, mode="train")
+    train_ds = DatasetSegmentation(annotations, processor, mode="train", gt_ratio=0.1)
 
     # Create a dataloader
     train_dataloader = DataLoader(


### PR DESCRIPTION
# 변경 사항
**기존 문제점**
- Fine Tuning용 학습 데이터와 평가 데이터 모두 UAD 추론 마스크를 사용함 
- UAD의 아웃풋이 없어 AUROC를 구할 수 없음 

**변경 사항**
- config 및 evaluate 코드에서 uad pred 데이터와 gt를 불러오는 분기 나눔 
- UAD의 logit을 저장 및 불러오는 로직을 추가하여 UAD의 AUROC를 계산하는 로직 추가 